### PR TITLE
Fix require in tests in Ruby 1.9

### DIFF
--- a/test/test_dimensions.rb
+++ b/test/test_dimensions.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require File.expand_path('../dimensions/test_case', __FILE__)
 
 class TestDimensions < Dimensions::TestCase
   def test_animated_gif_dimensions

--- a/test/test_exif_scanner.rb
+++ b/test/test_exif_scanner.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require File.expand_path('../dimensions/test_case', __FILE__)
 
 class TestExifScanner < Dimensions::TestCase
   def test_scanning_exif_with_top_left_orientation

--- a/test/test_jpeg_scanner.rb
+++ b/test/test_jpeg_scanner.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require File.expand_path('../dimensions/test_case', __FILE__)
 
 class TestJpegScanner < Dimensions::TestCase
   def test_scanning_jpeg

--- a/test/test_reader.rb
+++ b/test/test_reader.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require File.expand_path('../dimensions/test_case', __FILE__)
 
 class TestReader < Dimensions::TestCase
   def test_identifying_gif_file

--- a/test/test_tiff_scanner.rb
+++ b/test/test_tiff_scanner.rb
@@ -1,4 +1,4 @@
-require 'dimensions/test_case'
+require File.expand_path('../dimensions/test_case', __FILE__)
 
 class TestTiffScanner < Dimensions::TestCase
   def test_scanning_tiff_with_short_values


### PR DESCRIPTION
Ruby 1.9 doesn’t has `.` in `$LOAD_PATH`, so we need another way to require test helper to run tests.
