### PR TITLE
Get the dimensions of an unread IO stream by reading ahead

### DIFF
--- a/lib/dimensions/io.rb
+++ b/lib/dimensions/io.rb
@@ -17,15 +17,30 @@ module Dimensions
     end
 
     def width
+      peek
       @reader.width
     end
 
     def height
+      peek
       @reader.height
     end
 
     def angle
+      peek
       @reader.angle
     end
+
+    private
+      def peek
+        unless no_peeking?
+          read(pos + 1024) while @reader.width.nil? && pos < 6144
+          rewind
+        end
+      end
+
+      def no_peeking?
+        @reader.width || closed? || pos != 0
+      end
   end
 end

--- a/test/test_io.rb
+++ b/test/test_io.rb
@@ -1,0 +1,40 @@
+require 'dimensions/test_case'
+
+class TestIO < Dimensions::TestCase
+  def test_extends_io
+    with_extended_file do |file|
+      assert file.is_a?(Dimensions::IO)
+      assert file.respond_to?(:dimensions)
+    end
+  end
+
+  def test_peeks_ahead_to_determine_dimensions
+    with_extended_file do |file|
+      assert_equal 0, file.pos
+      assert file.width
+      assert_equal 0, file.pos
+    end
+  end
+
+  def test_skips_peeking_if_closed
+    with_extended_file do |file|
+      file.close
+      assert ! file.width
+    end
+  end
+
+  def test_skips_peeking_if_offset
+    with_extended_file do |file|
+      file.read 1
+      assert ! file.width
+      assert_equal 1, file.pos
+    end
+  end
+
+  private
+    def with_extended_file
+      with_fixture("screenshot.png") do |file|
+        yield Dimensions(file)
+      end
+    end
+end


### PR DESCRIPTION
Before:

``` ruby
>> Dimensions(File.open("masterpiece.png", "rb")).dimensions
=> nil
```

After:

``` ruby
>> Dimensions(File.open("masterpiece.png", "rb")).dimensions
=> [522, 606]
```
