### PR TITLE
Fix jpeg dimensions scan

### DIFF
--- a/lib/dimensions/io.rb
+++ b/lib/dimensions/io.rb
@@ -34,7 +34,7 @@ module Dimensions
     private
       def peek
         unless no_peeking?
-          read(pos + 1024) while @reader.width.nil? && pos < 6144
+          read(pos + 1024) while @reader.width.nil? && pos < 31745
           rewind
         end
       end


### PR DESCRIPTION
I don't have any idea why this fixes it for the image below, nor why it was set to 6144 on the first place.

http://media.palau.org/uploads/photos/JuddHealdHiRes.jpg

Maybe a better alternative would be to scan until you have tried the whole image.

See https://github.com/sstephenson/dimensions/pull/7
